### PR TITLE
Add index  and insured_person_by_email routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
+gem 'active_model_serializers'
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8.1)
       activesupport (= 7.0.8.1)
       globalid (>= 0.3.6)
@@ -87,6 +92,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -113,6 +120,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
+    jsonapi-renderer (0.2.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -266,6 +274,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap
   capybara
   debug

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ stop: # make stop container=rabbitmq
 server:
 	docker compose up -d
 	docker exec -it app /bin/sh -c "bin/setup \
-		&& bundle exec rails server --binding 0.0.0.0"
+		&& bundle exec rails server --binding 0.0.0.0 -p 3000"
 
 sneakers:
 	docker logs --follow sneakers

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -4,6 +4,12 @@ class PoliciesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def index
+    policies = Policy.all
+
+    render json: policies
+  end
+
+  def insured_person_by_email
     policies = Policy.joins(:insured_person).where(insured_people: { email: params[:email] })
 
     render json: policies

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -3,6 +3,12 @@
 class PoliciesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
+  def index
+    policies = Policy.joins(:insured_person).where(insured_people: { email: params[:email] })
+
+    render json: policies
+  end
+  
   def show
     policy = Policy.find(params[:id])
 

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -6,24 +6,19 @@ class PoliciesController < ApplicationController
   def index
     policies = Policy.all
 
-    render json: policies
+    render json: policies, each_serializer: PolicySerializer
   end
 
   def insured_person_by_email
-    policies = Policy.joins(:insured_person).where(insured_people: { email: params[:email] })
+    policies = Policy.by_email(params[:email])
 
-    render json: policies
+    render json: policies, each_serializer: PolicySerializer
   end
   
   def show
     policy = Policy.find(params[:id])
 
-    render json: policy,
-      except: [:created_at, :updated_at],
-      include: {
-        insured_person: { only: [:name, :document] },
-        vehicle: { only: [:brand, :vehicle_model, :year, :license_plate] }
-      }
+    render json: policy, serializer: PolicySerializer
   end
 
   private

--- a/app/models/insured_person.rb
+++ b/app/models/insured_person.rb
@@ -1,6 +1,6 @@
 class InsuredPerson < ApplicationRecord
   has_many :policies
   
-  validates :name, :document, presence: true  
-  validates :document, uniqueness: true
+  validates :name, :document, :email, presence: true  
+  validates :document, :email, uniqueness: true
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -13,4 +13,8 @@ class Policy < ApplicationRecord
       errors.add(:base, "Vehicle already has policy")
     end
   end
+
+  scope :by_email, lambda { |email|
+    joins(:insured_person).where(insured_people: { email: email })
+  }
 end

--- a/app/serializers/insured_person_serializer.rb
+++ b/app/serializers/insured_person_serializer.rb
@@ -1,0 +1,3 @@
+class InsuredPersonSerializer < ActiveModel::Serializer
+  attributes :name, :document, :email
+end

--- a/app/serializers/policy_serializer.rb
+++ b/app/serializers/policy_serializer.rb
@@ -1,0 +1,5 @@
+class PolicySerializer < ActiveModel::Serializer
+  attributes :effective_from, :effective_until
+  has_one :insured_person, serializer: InsuredPersonSerializer
+  has_one :vehicle, serializer: VehicleSerializer
+end

--- a/app/serializers/vehicle_serializer.rb
+++ b/app/serializers/vehicle_serializer.rb
@@ -1,0 +1,3 @@
+class VehicleSerializer < ActiveModel::Serializer
+  attributes :brand, :vehicle_model, :year, :license_plate
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   resources :policies, only: %i[show index]
+    
+  get 'insured_person/:email', to: 'policies#insured_person_by_email', as: 'insured_person_by_email', controller: 'policies', :constraints => { :email => /.*/ }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :policies, only: %i[show]
+  resources :policies, only: %i[show index]
 end

--- a/db/migrate/20240417153752_add_email_to_insured_people.rb
+++ b/db/migrate/20240417153752_add_email_to_insured_people.rb
@@ -1,0 +1,5 @@
+class AddEmailToInsuredPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :insured_people, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_170534) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_17_153752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_170534) do
     t.string "document"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email"
     t.index ["document"], name: "index_insured_people_on_document", unique: true
   end
 

--- a/spec/controllers/policy_controller_spec.rb
+++ b/spec/controllers/policy_controller_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Policy', type: :request do
+  context '#show' do
+    subject(:request) { get policy_path(id) }
+
+    context 'when find policy' do
+      let(:policy) do
+        Policy.create!(
+          effective_from: Date.today,
+          effective_until: 1.year.from_now,
+          insured_person_attributes: {
+            name: 'Maria Silva',
+            document: '123.456.789-00',
+            email: 'maria@email.com'
+          },
+          vehicle_attributes: {
+            brand: "New brand",
+            vehicle_model: "Gol 1.6",
+            year: "2022",
+            license_plate: 'ABC-1234'
+          }
+        )
+      end
+      let(:id) { policy.id }
+
+      it 'return success' do
+        request
+
+        expect(response).to have_http_status(200)
+        expect(JSON.parse(response.body)['id']).to eq policy.id
+      end
+    end
+
+    context 'when does NOT find policy' do
+      let(:id) { 1 }
+
+      it 'return 404' do
+        request
+
+        expect(response).to have_http_status(404)
+        expect(response.body).to eq ''
+      end
+    end
+  end
+
+  context '#index' do
+    subject(:request) { get policies_path(email: email) }
+    let(:policy) do
+      Policy.create!(
+        effective_from: Date.today,
+        effective_until: 1.year.from_now,
+        insured_person_attributes: {
+          name: 'Maria Silva',
+          email: email,
+          document: '123.456.789-00'
+        },
+        vehicle_attributes: {
+          brand: "New brand",
+          vehicle_model: "Gol 1.6",
+          year: "2022",
+          license_plate: 'ABC-1234'
+        }
+      )
+    end
+
+    context 'when insured person has policy' do
+      let(:email) { 'maria@email.com' }
+
+      before { policy }
+
+      it 'return policies from given email' do
+        request
+        response_body = JSON.parse(response.body)
+
+        expect(response).to have_http_status(200)
+        expect(response_body.first['id']).to eq policy.id
+      end
+    end
+
+    context 'when insured person does NOT have policy' do
+      let(:email) { 'another@email.com' }
+
+      it 'return policies from given email' do
+        request
+        response_body = JSON.parse(response.body)
+
+        expect(response).to have_http_status(200)
+        expect(response_body).to eq []
+      end
+    end
+  end  
+end

--- a/spec/controllers/policy_controller_spec.rb
+++ b/spec/controllers/policy_controller_spec.rb
@@ -3,34 +3,50 @@
 require 'rails_helper'
 
 RSpec.describe 'Policy', type: :request do
+  let(:vehicle_attributes) do
+    {
+      brand: "New brand",
+      vehicle_model: "Gol 1.6",
+      year: 2022,
+      license_plate: 'ABC-1234'
+    }
+  end
+  let(:insured_person_attributes) do
+    {
+      name: 'Maria Silva',
+      document: '123.456.789-00',
+      email: 'maria@email.com'
+    }
+  end
+  let(:policy_response) do
+    {
+      effective_from: '2024-04-18',
+      effective_until: '2025-04-18',
+      insured_person: insured_person_attributes,
+      vehicle: vehicle_attributes
+    }.deep_stringify_keys
+  end
+  
   context '#show' do
     subject(:request) { get policy_path(id) }
-
     context 'when find policy' do
       let(:policy) do
         Policy.create!(
           effective_from: Date.today,
           effective_until: 1.year.from_now,
-          insured_person_attributes: {
-            name: 'Maria Silva',
-            document: '123.456.789-00',
-            email: 'maria@email.com'
-          },
-          vehicle_attributes: {
-            brand: "New brand",
-            vehicle_model: "Gol 1.6",
-            year: "2022",
-            license_plate: 'ABC-1234'
-          }
+          insured_person_attributes: insured_person_attributes,
+          vehicle_attributes: vehicle_attributes
         )
       end
       let(:id) { policy.id }
+
+      let(:request_response) { policy_response }
 
       it 'return success' do
         request
 
         expect(response).to have_http_status(200)
-        expect(JSON.parse(response.body)['id']).to eq policy.id
+        expect(JSON.parse(response.body)).to include(request_response)
       end
     end
 
@@ -53,21 +69,14 @@ RSpec.describe 'Policy', type: :request do
       Policy.create!(
         effective_from: Date.today,
         effective_until: 1.year.from_now,
-        insured_person_attributes: {
-          name: 'Maria Silva',
-          email: 'maria@email.com',
-          document: '123.456.789-00'
-        },
-        vehicle_attributes: {
-          brand: "New brand",
-          vehicle_model: "Gol 1.6",
-          year: "2022",
-          license_plate: 'ABC-1234'
-        }
+        insured_person_attributes: insured_person_attributes,
+        vehicle_attributes: vehicle_attributes
       )
     end
   
     context 'there are policies created' do
+      let(:request_response) { [policy_response] }
+
       it 'list policies' do
         policy
         request
@@ -75,7 +84,7 @@ RSpec.describe 'Policy', type: :request do
         response_body = JSON.parse(response.body)
 
         expect(response).to have_http_status(200)
-        expect(response_body.first['id']).to eq policy.id
+        expect(response_body).to eq request_response
       end
     end
 
@@ -98,22 +107,14 @@ RSpec.describe 'Policy', type: :request do
       Policy.create!(
         effective_from: Date.today,
         effective_until: 1.year.from_now,
-        insured_person_attributes: {
-          name: 'Maria Silva',
-          email: email,
-          document: '123.456.789-00'
-        },
-        vehicle_attributes: {
-          brand: "New brand",
-          vehicle_model: "Gol 1.6",
-          year: "2022",
-          license_plate: 'ABC-1234'
-        }
+        insured_person_attributes: insured_person_attributes,
+        vehicle_attributes: vehicle_attributes
       )
     end
 
     context 'when insured person has policy' do
       let(:email) { 'maria@email.com' }
+      let(:request_response) { [policy_response] }
 
       before { policy }
 
@@ -122,7 +123,7 @@ RSpec.describe 'Policy', type: :request do
         response_body = JSON.parse(response.body)
         
         expect(response).to have_http_status(200)
-        expect(response_body.first['id']).to eq policy.id
+        expect(response_body).to eq request_response
       end
     end
 

--- a/spec/controllers/policy_controller_spec.rb
+++ b/spec/controllers/policy_controller_spec.rb
@@ -47,7 +47,53 @@ RSpec.describe 'Policy', type: :request do
   end
 
   context '#index' do
-    subject(:request) { get policies_path(email: email) }
+    subject(:request) { get policies_path }
+
+    let(:policy) do
+      Policy.create!(
+        effective_from: Date.today,
+        effective_until: 1.year.from_now,
+        insured_person_attributes: {
+          name: 'Maria Silva',
+          email: 'maria@email.com',
+          document: '123.456.789-00'
+        },
+        vehicle_attributes: {
+          brand: "New brand",
+          vehicle_model: "Gol 1.6",
+          year: "2022",
+          license_plate: 'ABC-1234'
+        }
+      )
+    end
+  
+    context 'there are policies created' do
+      it 'list policies' do
+        policy
+        request
+
+        response_body = JSON.parse(response.body)
+
+        expect(response).to have_http_status(200)
+        expect(response_body.first['id']).to eq policy.id
+      end
+    end
+
+    context 'there are policies created' do
+      it 'list policies' do
+        request
+
+        response_body = JSON.parse(response.body)
+
+        expect(response).to have_http_status(200)
+        expect(response_body).to eq []
+      end
+    end
+  end
+
+  context '#insured_person_policies_by_email' do
+    subject(:request) { get "/insured_person/#{email}" }
+
     let(:policy) do
       Policy.create!(
         effective_from: Date.today,
@@ -74,7 +120,7 @@ RSpec.describe 'Policy', type: :request do
       it 'return policies from given email' do
         request
         response_body = JSON.parse(response.body)
-
+        
         expect(response).to have_http_status(200)
         expect(response_body.first['id']).to eq policy.id
       end

--- a/spec/models/insured_person_spec.rb
+++ b/spec/models/insured_person_spec.rb
@@ -5,12 +5,13 @@ require 'rails_helper'
 RSpec.describe InsuredPerson, type: :model do
   describe 'Validations' do
     subject(:new_insured_person) do
-      described_class.create(name: name, document: document)
+      described_class.create(name: name, document: document, email: email)
     end
 
     context 'when has name and document' do
       let(:name) { 'bolinha silva' }
       let(:document) { '123456789' }
+      let(:email) { 'bolinha@email.com' }
 
       it 'creates a insured person' do
         expect{ subject }.to change { InsuredPerson.count }.by 1
@@ -20,6 +21,7 @@ RSpec.describe InsuredPerson, type: :model do
     context 'missing params' do
       let(:name) { '' }
       let(:document) { '' }
+      let(:email) { '' }
 
       it 'does NOT create a insured person' do
         expect{ subject }.not_to change { InsuredPerson.count }
@@ -27,7 +29,11 @@ RSpec.describe InsuredPerson, type: :model do
 
       it 'returns missing attributes messages' do
         expect(subject.errors.full_messages).to eq(
-          ["Name can't be blank", "Document can't be blank"]
+          [
+            "Name can't be blank",
+            "Document can't be blank",
+            "Email can't be blank"
+          ]
         )
       end
     end
@@ -35,9 +41,13 @@ RSpec.describe InsuredPerson, type: :model do
     context 'when insured_person with document that already exists' do
       let(:document) { '123456789' }
       let(:name) { 'Another name' }
+      let(:email) { 'another_email@email.com' }
 
       before do
-        InsuredPerson.create!(name: 'Bolinha Silva', document: document)
+        InsuredPerson.create!(
+          name: 'Bolinha Silva',
+          document: document,
+          email: 'bolinha@email.com')
       end
 
       it 'does NOT create a insured person' do
@@ -47,6 +57,29 @@ RSpec.describe InsuredPerson, type: :model do
       it 'returns missing attributes messages' do
         expect(subject.errors.full_messages).to eq(
           ["Document has already been taken"]
+        )
+      end
+    end
+
+    context 'when insured_person with email that already exists' do
+      let(:document) { '123456789' }
+      let(:name) { 'Another name' }
+      let(:email) { 'bolinha@email.com' }
+
+      before do
+        InsuredPerson.create!(
+          name: 'Bolinha Silva',
+          document: '987654321',
+          email: email)
+      end
+
+      it 'does NOT create a insured person' do
+        expect{ subject }.not_to change { InsuredPerson.count }
+      end
+
+      it 'returns missing attributes messages' do
+        expect(subject.errors.full_messages).to eq(
+          ["Email has already been taken"]
         )
       end
     end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Policy, type: :model do
     let(:insured_person_attributes) do
       {
         name: 'Maria Silva',
-        document: '123.456.789-00'
+        document: '123.456.789-00',
+        email: 'maria@email.com'
       }
     end
     let(:license_plate) { 'ABC-5678' }
@@ -86,7 +87,8 @@ RSpec.describe Policy, type: :model do
       let(:insured_person_attributes) do
         {
           name: 'Maria Silva',
-          document: '123.456.789-00'
+          document: '123.456.789-00',
+          email: 'maria@email.com'
         }
       end
       subject(:new_policy) do
@@ -120,7 +122,8 @@ RSpec.describe Policy, type: :model do
       let(:insured_person_attributes) do
         {
           name: 'Maria Silva',
-          document: '123.456.789-00'
+          document: '123.456.789-00',
+          email: 'maria@email.com'
         }
       end
       let(:vehicle_attributes) do
@@ -144,7 +147,8 @@ RSpec.describe Policy, type: :model do
       let(:another_insured_person) do
         InsuredPerson.create!(
           name: 'Another Person',
-          document: '987.654.321-00'
+          document: '987.654.321-00',
+          email: 'another_email@email.com'
         )
       end
 

--- a/spec/services/create_policy_service_spec.rb
+++ b/spec/services/create_policy_service_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe CreatePolicyService do
       let(:new_insured_person_attr) do
         {
           name: 'Maria Silva',
-          document: '123.456.789-00'
+          document: '123.456.789-00',
+          email: 'maria@email.com'
         }
       end
       let(:new_vehicle_attr) do
@@ -73,7 +74,8 @@ RSpec.describe CreatePolicyService do
       let(:old_insured_person) do
         {
           name: 'Old Name',
-          document: '000.000.000-00'
+          document: '000.000.000-00',
+          email: 'another_email@email.com'
         }
       end      
       let(:old_vehicle) do
@@ -157,7 +159,8 @@ RSpec.describe CreatePolicyService do
         let(:new_insured_person_attr) do
           {
             name: 'Maria Silva',
-            document: '123.456.789-00'
+            document: '123.456.789-00',
+            email: 'maria@email.com'
           }
         end
 


### PR DESCRIPTION
Adicionei uma rota index que irá pegar todas as apolices e outra rota para listar as apolices de um segurado atraves do email.
E já havia criado uma rota show das apolices.